### PR TITLE
Fix notes missing on agenda pagination

### DIFF
--- a/Orders Overzicht Hagemab.php
+++ b/Orders Overzicht Hagemab.php
@@ -1479,6 +1479,7 @@ function wc_orders_week_agenda_ajax_handler() {
             'maatwerk_telefoonnummer'   => $maatwerk_telefoonnummer,
             'postcode'                  => $postcode,
             'opmerkingen'               => $opmerkingen,
+            'important_opmerking'       => $important_opmerking,
             'aantal_medewerkers'        => $aantal_medewerkers,
             'aantal_personen_raw'       => $aantal_personen,
             'optie_geldig_tot'          => $optie_geldig_tot, // Voeg optie_geldig_tot toe aan de agenda array


### PR DESCRIPTION
## Summary
- include the `important_opmerking` meta value in the AJAX response

## Testing
- `php -l 'Orders Overzicht Hagemab.php'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b642b94c8320b1286d8f469b207e